### PR TITLE
Add several TTY_SHARE_* session environment variables

### DIFF
--- a/pty_master.go
+++ b/pty_master.go
@@ -30,8 +30,9 @@ func isStdinTerminal() bool {
 	return terminal.IsTerminal(0)
 }
 
-func (pty *ptyMaster) Start(command string, args []string) (err error) {
+func (pty *ptyMaster) Start(command string, args []string, envVars []string) (err error) {
 	pty.command = exec.Command(command, args...)
+	pty.command.Env = envVars
 	pty.ptyFile, err = ptyDevice.Start(pty.command)
 
 	if err != nil {


### PR DESCRIPTION
Set these variables in the started child shell process:
- TTY_SHARE=1 to signal running inside a tty-share session
- TTY_SHARE_LOCAL_URL - contains the URL of the public session
- TTY_SHARE_PUBLIC_URL - contains the URL of the local session