### PR TITLE
Automatically build and publish releases

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,37 @@
+---
+name: releases
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  gh_tagged_release:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout source code"
+        uses: "actions/checkout@v2.3.4"
+        with:
+          lfs: true
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Build for Linux-amd64
+        run: GOOS=linux GOARCH=amd64 go build -x -v -mod=vendor -ldflags "-X main.version=$(echo ${GITHUB_REF} |  awk -F/ '{print substr($3,2,10);}') -w -s" -o tty-share_linux-amd64
+      - name: Build for Linux-i386
+        run: GOOS=linux GOARCH=386 go build -x -v -mod=vendor -ldflags "-X main.version=$(echo ${GITHUB_REF} |  awk -F/ '{print substr($3,2,10);}') -w -s" -o tty-share_linux-i386
+      - name: Build for Darwin-amd64
+        run: GOOS=darwin GOARCH=amd64 go build -x -v -mod=vendor -ldflags "-X main.version=$(echo ${GITHUB_REF} | awk -F/ '{print substr($3,2,10);}') -w -s" -o tty-share_darwin-amd64
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: |
+            tty-share_*
+        id: "automatic_releases"

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -7,11 +7,21 @@ on:
       - "v*"
 
 jobs:
-  gh_tagged_release:
-    runs-on: "ubuntu-latest"
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build targets
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: '386'
+          - goos: darwin
+            goarch: amd64
     steps:
-      - name: "Checkout source code"
-        uses: "actions/checkout@v2.3.4"
+      - name: Checkout source code
+        uses: actions/checkout@v2.3.4
         with:
           lfs: true
           fetch-depth: 0
@@ -22,11 +32,29 @@ jobs:
           go-version: 1.15
 
       - name: Build for Linux-amd64
-        run: GOOS=linux GOARCH=amd64 go build -x -v -mod=vendor -ldflags "-X main.version=$(echo ${GITHUB_REF} |  awk -F/ '{print substr($3,2,10);}') -w -s" -o tty-share_linux-amd64
-      - name: Build for Linux-i386
-        run: GOOS=linux GOARCH=386 go build -x -v -mod=vendor -ldflags "-X main.version=$(echo ${GITHUB_REF} |  awk -F/ '{print substr($3,2,10);}') -w -s" -o tty-share_linux-i386
-      - name: Build for Darwin-amd64
-        run: GOOS=darwin GOARCH=amd64 go build -x -v -mod=vendor -ldflags "-X main.version=$(echo ${GITHUB_REF} | awk -F/ '{print substr($3,2,10);}') -w -s" -o tty-share_darwin-amd64
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+
+        run: |
+          v=$(echo ${GITHUB_REF} | awk -F/ '{print substr($3,2,10);}')
+          go build -x -v -mod=vendor -ldflags "-X main.version=${v} -w -s" -o "tty-share_${GOOS}-${GOARCH}"
+
+      - name: Upload to artifact storage
+        uses: actions/upload-artifact@v2
+        with:
+          path: tty-share_${{ matrix.goos }}-${{ matrix.goarch }}
+          if-no-files-found: error
+          # only meant for sharing with the publish job
+          retention-days: 1
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          path: tty-share_*
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:


### PR DESCRIPTION
Adds a GitHub action to automatically build and publish releases when
a tag matching "v*" is pushed.

Makes use of https://github.com/marvinpinto/action-automatic-releases

A "nothing up my sleeve" solution to release builds.
Closes #23 and #44