### PR TITLE
server/frontend/templates/tty-share.in.html: dont try to download favicon.ico

### DIFF
--- a/server/frontend/templates/tty-share.in.html
+++ b/server/frontend/templates/tty-share.in.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
+        <link rel="icon" href="data:;base64,=">
         <title>tty-share</title>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/nf-sauce-code-pro@2.1.3/nf-font.min.css">
     </head>


### PR DESCRIPTION
hi @elisescu, please take a look :pray: 

this prevents the browser from trying to download a favicon.ico, which is useful with `--base-url-path` - testing with a reverse proxy where no path is configured outside of the tty-share base path, i found that disconnects/erroneous HTTP responses from trying to fetch `/favicon.ico` caused further requests by the browser inside the base path to hang (eg fetching the js or opening the websocket).

this sets an "empty" icon and prevents the request outside of the base path.

