### PR TITLE
fix Print format calls

### DIFF
--- a/client.go
+++ b/client.go
@@ -194,13 +194,13 @@ func (c *ttyShareClient) Run() (err error) {
 			localTunconn, err := localListener.Accept()
 
 			if err != nil {
-				log.Warnf("Cannot accept local tunnel connections: ", err.Error())
+				log.Warn("Cannot accept local tunnel connections: ", err.Error())
 				return
 			}
 
 			muxClient, err := c.tunnelMuxSession.Open()
 			if err != nil {
-				log.Warnf("Cannot create a muxer to the remote, over ws: ", err.Error())
+				log.Warn("Cannot create a muxer to the remote, over ws: ", err.Error())
 				return
 			}
 

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ Flags:
 	envVars := os.Environ()
 	envVars = append(envVars,
 		fmt.Sprintf("TTY_SHARE_LOCAL_URL=http://%s", *listenAddress),
-		fmt.Sprintf("TTY_SHARE=1", os.Getpid()),
+		"TTY_SHARE=1",
 	)
 
 	if publicURL != "" {

--- a/server/server.go
+++ b/server/server.go
@@ -226,7 +226,7 @@ func (server *TTYServer) handleTunnelWebsocket(w http.ResponseWriter, r *http.Re
 	server.muxTunnelSession, err = yamux.Server(wsRW, nil)
 
 	if err != nil {
-		log.Errorf("Could not open a mux server: ", err.Error())
+		log.Error("Could not open a mux server: ", err.Error())
 		return
 	}
 


### PR DESCRIPTION
discovered when running `go test`:

```
./client.go:197:14: github.com/sirupsen/logrus.Warnf call has arguments but no formatting directives                                                                                                                                                                          
./client.go:203:14: github.com/sirupsen/logrus.Warnf call has arguments but no formatting directives
./main.go:163:14: fmt.Sprintf call has arguments but no formatting directives
```

```
./server.go:229:13: github.com/sirupsen/logrus.Errorf call has arguments but no formatting directives
```
