### PR TITLE
Satisfy opensvc requirements

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -38,9 +39,10 @@ type ttyShareClient struct {
 	}
 	winSizesMutex    sync.Mutex
 	tunnelMuxSession *yamux.Session
+	insecure         bool
 }
 
-func newTtyShareClient(url string, detachKeys string, tunnelConfig *string) *ttyShareClient {
+func newTtyShareClient(url string, detachKeys string, tunnelConfig *string, insecure bool) *ttyShareClient {
 	return &ttyShareClient{
 		url:             url,
 		ttyWsConn:       nil,
@@ -48,6 +50,7 @@ func newTtyShareClient(url string, detachKeys string, tunnelConfig *string) *tty
 		wcChan:          make(chan os.Signal, 1),
 		ioFlagAtomic:    1,
 		tunnelAddresses: tunnelConfig,
+		insecure:        insecure,
 	}
 }
 
@@ -105,10 +108,30 @@ func (c *ttyShareClient) updateThisWinSize() {
 func (c *ttyShareClient) Run() (err error) {
 	log.Debugf("Connecting as a client to %s ..", c.url)
 
-	resp, err := http.Get(c.url)
+	httpURL, err := url.Parse(c.url)
+	if err != nil {
+		return
+	}
+
+	client := &http.Client{}
+
+	if httpURL.Scheme == "https" {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: c.insecure,
+			},
+		}
+	}
+	resp, err := client.Get(c.url)
 
 	if err != nil {
 		return
+	}
+
+	// Build the WS URL from the host part of the given http URL and the wsPath
+	wsScheme := "ws"
+	if httpURL.Scheme == "https" {
+		wsScheme = "wss"
 	}
 
 	// Get the path of the websockts route from the header
@@ -117,21 +140,20 @@ func (c *ttyShareClient) Run() (err error) {
 
 	ttyTunnelPath := resp.Header.Get("TTYSHARE-TUNNEL-WSPATH")
 
-	// Build the WS URL from the host part of the given http URL and the wsPath
-	httpURL, err := url.Parse(c.url)
-	if err != nil {
-		return
-	}
-	wsScheme := "ws"
-	if httpURL.Scheme == "https" {
-		wsScheme = "wss"
-	}
 	ttyWsURL := wsScheme + "://" + httpURL.Host + ttyWsPath
 	ttyTunnelURL := wsScheme + "://" + httpURL.Host + ttyTunnelPath
 
 	log.Debugf("Built the WS URL from the headers: %s", ttyWsURL)
 
-	c.ttyWsConn, _, err = websocket.DefaultDialer.Dial(ttyWsURL, nil)
+	dialer := websocket.DefaultDialer
+	if httpURL.Scheme == "https" && c.insecure {
+		dialer.TLSClientConfig = &tls.Config{
+			// Set InsecureSkipVerify to true to disable certificate validation
+			InsecureSkipVerify: true,
+		}
+	}
+
+	c.ttyWsConn, _, err = dialer.Dial(ttyWsURL, nil)
 	if err != nil {
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -19,17 +20,17 @@ import (
 // complex linker flags that could set the version from the outside
 var version string = "2.4.1"
 
-func createServer(frontListenAddress string, frontendPath string, pty server.PTYHandler, sessionID string, allowTunneling bool, crossOrigin bool, baseUrlPath string, greetTimeout time.Duration, seats int) *server.TTYServer {
+func createServer(frontListener net.Listener, frontendPath string, pty server.PTYHandler, sessionID string, allowTunneling bool, crossOrigin bool, baseUrlPath string, greetTimeout time.Duration, seats int) *server.TTYServer {
 	config := ttyServer.TTYServerConfig{
-		FrontListenAddress: frontListenAddress,
-		FrontendPath:       frontendPath,
-		PTY:                pty,
-		SessionID:          sessionID,
-		AllowTunneling:     allowTunneling,
-		CrossOrigin:        crossOrigin,
-		BaseUrlPath:        baseUrlPath,
-		GreetTimeout:       greetTimeout,
-		Seats:              seats,
+		FrontListener:  frontListener,
+		FrontendPath:   frontendPath,
+		PTY:            pty,
+		SessionID:      sessionID,
+		AllowTunneling: allowTunneling,
+		CrossOrigin:    crossOrigin,
+		BaseUrlPath:    baseUrlPath,
+		GreetTimeout:   greetTimeout,
+		Seats:          seats,
 	}
 
 	server := ttyServer.NewTTYServer(config)
@@ -77,7 +78,7 @@ Flags:
 	}
 	commandArgs := flag.String("args", "", "[s] The command arguments")
 	logFileName := flag.String("logfile", "-", "The name of the file to log")
-	listenAddress := flag.String("listen", "localhost:8000", "[s] tty-server address")
+	listenAddress := flag.String("listen", "localhost:8000", "[s] tty-server address, \"localhost:0\" to allocate a free port")
 	versionFlag := flag.Bool("version", false, "Print the tty-share version")
 	frontendPath := flag.String("frontend-path", "", "[s] The path to the frontend resources. By default, these resources are included in the server binary, so you only need this path if you don't want to use the bundled ones.")
 	proxyServerAddress := flag.String("tty-proxy", "on.tty-share.com:4567", "[s] Address of the proxy for public facing connections")
@@ -147,6 +148,16 @@ Flags:
 		os.Exit(1)
 	}
 
+	// allocate a free port if port is zero
+	listener, err := net.Listen("tcp", *listenAddress)
+	if err != nil {
+		log.Errorf("Can't listen on %s: %s\n", *listenAddress, err.Error())
+		return
+	}
+
+	defer listener.Close()
+	*listenAddress = listener.Addr().String()
+
 	sessionID := ""
 	publicURL := ""
 	if *publicSession {
@@ -175,7 +186,7 @@ Flags:
 	}
 
 	ptyMaster := ptyMasterNew(*headless, *headlessCols, *headlessRows)
-	err := ptyMaster.Start(*commandName, strings.Fields(*commandArgs), envVars)
+	err = ptyMaster.Start(*commandName, strings.Fields(*commandArgs), envVars)
 	if err != nil {
 		log.Errorf("Cannot start the %s command: %s", *commandName, err.Error())
 		return
@@ -214,7 +225,7 @@ Flags:
 		pty = &nilPTY{}
 	}
 
-	server := createServer(*listenAddress, *frontendPath, pty, sessionID, *allowTunneling, *crossOrgin, sanitizedBaseUrlPath, *greetTimeout, *seats)
+	server := createServer(listener, *frontendPath, pty, sessionID, *allowTunneling, *crossOrgin, sanitizedBaseUrlPath, *greetTimeout, *seats)
 	if cols, rows, e := ptyMaster.GetWinSize(); e == nil {
 		server.WindowSize(cols, rows)
 	}

--- a/main.go
+++ b/main.go
@@ -92,6 +92,7 @@ Flags:
 	greetTimeout := flag.Duration("greet-timeout", 0, "[s] Maximum duration clients are accepted. Set to 0 for no limit.")
 	seats := flag.Int("seats", 0, "[s] The number of allowed proxy connections. Zero means as many as possible.")
 	detachKeys := flag.String("detach-keys", "ctrl-o,ctrl-c", "[c] Sequence of keys to press for closing the connection. Supported: https://godoc.org/github.com/moby/term#pkg-variables.")
+	insecure := flag.Bool("k", false, "Accept to run with a proxy presenting a invalid certificate.")
 	allowTunneling := flag.Bool("A", false, "[s] Allow clients to create a TCP tunnel")
 	tunnelConfig := flag.String("L", "", "[c] TCP tunneling addresses: local_port:remote_host:remote_port. The client will listen on local_port for TCP connections, and will forward those to the from the server side to remote_host:remote_port")
 	crossOrgin := flag.Bool("cross-origin", false, "[s] Allow cross origin requests to the server")
@@ -132,7 +133,7 @@ Flags:
 	if len(args) == 1 {
 		connectURL := args[0]
 
-		client := newTtyShareClient(connectURL, *detachKeys, tunnelConfig)
+		client := newTtyShareClient(connectURL, *detachKeys, tunnelConfig, *insecure)
 
 		err := client.Run()
 		if err != nil {
@@ -161,7 +162,7 @@ Flags:
 	sessionID := ""
 	publicURL := ""
 	if *publicSession {
-		proxy, err := proxy.NewProxyConnection(*listenAddress, *proxyServerAddress, *noTLS)
+		proxy, err := proxy.NewProxyConnection(*listenAddress, *proxyServerAddress, *noTLS, *insecure)
 		if err != nil {
 			log.Errorf("Can't connect to the proxy: %s\n", err.Error())
 			return

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/elisescu/tty-share/proxy"
 	"github.com/elisescu/tty-share/server"
@@ -18,7 +19,7 @@ import (
 // complex linker flags that could set the version from the outside
 var version string = "2.4.1"
 
-func createServer(frontListenAddress string, frontendPath string, pty server.PTYHandler, sessionID string, allowTunneling bool, crossOrigin bool, baseUrlPath string) *server.TTYServer {
+func createServer(frontListenAddress string, frontendPath string, pty server.PTYHandler, sessionID string, allowTunneling bool, crossOrigin bool, baseUrlPath string, greetTimeout time.Duration) *server.TTYServer {
 	config := ttyServer.TTYServerConfig{
 		FrontListenAddress: frontListenAddress,
 		FrontendPath:       frontendPath,
@@ -27,6 +28,7 @@ func createServer(frontListenAddress string, frontendPath string, pty server.PTY
 		AllowTunneling:     allowTunneling,
 		CrossOrigin:        crossOrigin,
 		BaseUrlPath:        baseUrlPath,
+		GreetTimeout:       greetTimeout,
 	}
 
 	server := ttyServer.NewTTYServer(config)
@@ -85,6 +87,7 @@ Flags:
 	headless := flag.Bool("headless", false, "[s] Don't expect an interactive terminal at stdin")
 	headlessCols := flag.Int("headless-cols", 80, "[s] Number of cols for the allocated pty when running headless")
 	headlessRows := flag.Int("headless-rows", 25, "[s] Number of rows for the allocated pty when running headless")
+	greetTimeout := flag.Duration("greet-timeout", 0, "[s] Maximum duration clients are accepted. Set to 0 for no limit.")
 	detachKeys := flag.String("detach-keys", "ctrl-o,ctrl-c", "[c] Sequence of keys to press for closing the connection. Supported: https://godoc.org/github.com/moby/term#pkg-variables.")
 	allowTunneling := flag.Bool("A", false, "[s] Allow clients to create a TCP tunnel")
 	tunnelConfig := flag.String("L", "", "[c] TCP tunneling addresses: local_port:remote_host:remote_port. The client will listen on local_port for TCP connections, and will forward those to the from the server side to remote_host:remote_port")
@@ -209,7 +212,7 @@ Flags:
 		pty = &nilPTY{}
 	}
 
-	server := createServer(*listenAddress, *frontendPath, pty, sessionID, *allowTunneling, *crossOrgin, sanitizedBaseUrlPath)
+	server := createServer(*listenAddress, *frontendPath, pty, sessionID, *allowTunneling, *crossOrgin, sanitizedBaseUrlPath, *greetTimeout)
 	if cols, rows, e := ptyMaster.GetWinSize(); e == nil {
 		server.WindowSize(cols, rows)
 	}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bufio"
+	"crypto/x509"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -10,15 +12,19 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/elisescu/tty-share/proxy"
 	"github.com/elisescu/tty-share/server"
 	ttyServer "github.com/elisescu/tty-share/server"
-	log "github.com/sirupsen/logrus"
 )
 
 // This should be updated manually. Most of distro packagers prefer to build golang without
 // complex linker flags that could set the version from the outside
 var version string = "2.4.1"
+
+const exitCodex509UnknownAuthorityError = 2
+const exitCodeGenericError = 1
 
 func createServer(frontListener net.Listener, frontendPath string, pty server.PTYHandler, sessionID string, allowTunneling bool, crossOrigin bool, baseUrlPath string, greetTimeout time.Duration, seats int) *server.TTYServer {
 	config := ttyServer.TTYServerConfig{
@@ -137,7 +143,13 @@ Flags:
 
 		err := client.Run()
 		if err != nil {
+			if errors.As(err, &x509.UnknownAuthorityError{}) || errors.As(err, &x509.HostnameError{}) {
+				_, suffix, _ := strings.Cut(err.Error(), ": ")
+				fmt.Printf("%s\n", suffix)
+				os.Exit(exitCodex509UnknownAuthorityError)
+			}
 			fmt.Printf("Cannot connect to the remote session. Make sure the URL points to a valid tty-share session.\n")
+			os.Exit(exitCodeGenericError)
 		}
 		fmt.Printf("\ntty-share disconnected\n\n")
 		return
@@ -146,7 +158,7 @@ Flags:
 	// tty-share works as a server, from here on
 	if !isStdinTerminal() && !*headless {
 		fmt.Printf("Input not a tty\n")
-		os.Exit(1)
+		os.Exit(exitCodeGenericError)
 	}
 
 	// allocate a free port if port is zero
@@ -165,7 +177,10 @@ Flags:
 		proxy, err := proxy.NewProxyConnection(*listenAddress, *proxyServerAddress, *noTLS, *insecure)
 		if err != nil {
 			log.Errorf("Can't connect to the proxy: %s\n", err.Error())
-			return
+			if errors.As(err, &x509.UnknownAuthorityError{}) || errors.As(err, &x509.HostnameError{}) {
+				os.Exit(exitCodex509UnknownAuthorityError)
+			}
+			os.Exit(exitCodeGenericError)
 		}
 
 		go proxy.RunProxy()

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 // complex linker flags that could set the version from the outside
 var version string = "2.4.1"
 
-func createServer(frontListenAddress string, frontendPath string, pty server.PTYHandler, sessionID string, allowTunneling bool, crossOrigin bool, baseUrlPath string, greetTimeout time.Duration) *server.TTYServer {
+func createServer(frontListenAddress string, frontendPath string, pty server.PTYHandler, sessionID string, allowTunneling bool, crossOrigin bool, baseUrlPath string, greetTimeout time.Duration, seats int) *server.TTYServer {
 	config := ttyServer.TTYServerConfig{
 		FrontListenAddress: frontListenAddress,
 		FrontendPath:       frontendPath,
@@ -29,6 +29,7 @@ func createServer(frontListenAddress string, frontendPath string, pty server.PTY
 		CrossOrigin:        crossOrigin,
 		BaseUrlPath:        baseUrlPath,
 		GreetTimeout:       greetTimeout,
+		Seats:              seats,
 	}
 
 	server := ttyServer.NewTTYServer(config)
@@ -88,6 +89,7 @@ Flags:
 	headlessCols := flag.Int("headless-cols", 80, "[s] Number of cols for the allocated pty when running headless")
 	headlessRows := flag.Int("headless-rows", 25, "[s] Number of rows for the allocated pty when running headless")
 	greetTimeout := flag.Duration("greet-timeout", 0, "[s] Maximum duration clients are accepted. Set to 0 for no limit.")
+	seats := flag.Int("seats", 0, "[s] The number of allowed proxy connections. Zero means as many as possible.")
 	detachKeys := flag.String("detach-keys", "ctrl-o,ctrl-c", "[c] Sequence of keys to press for closing the connection. Supported: https://godoc.org/github.com/moby/term#pkg-variables.")
 	allowTunneling := flag.Bool("A", false, "[s] Allow clients to create a TCP tunnel")
 	tunnelConfig := flag.String("L", "", "[c] TCP tunneling addresses: local_port:remote_host:remote_port. The client will listen on local_port for TCP connections, and will forward those to the from the server side to remote_host:remote_port")
@@ -212,7 +214,7 @@ Flags:
 		pty = &nilPTY{}
 	}
 
-	server := createServer(*listenAddress, *frontendPath, pty, sessionID, *allowTunneling, *crossOrgin, sanitizedBaseUrlPath, *greetTimeout)
+	server := createServer(*listenAddress, *frontendPath, pty, sessionID, *allowTunneling, *crossOrgin, sanitizedBaseUrlPath, *greetTimeout, *seats)
 	if cols, rows, e := ptyMaster.GetWinSize(); e == nil {
 		server.WindowSize(cols, rows)
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -30,7 +30,7 @@ type proxyConnection struct {
 	PublicURL       string
 }
 
-func NewProxyConnection(backConnAddrr, proxyAddr string, noTLS bool) (*proxyConnection, error) {
+func NewProxyConnection(backConnAddrr, proxyAddr string, noTLS bool, insecure bool) (*proxyConnection, error) {
 	var conn net.Conn
 	var err error
 
@@ -44,7 +44,11 @@ func NewProxyConnection(backConnAddrr, proxyAddr string, noTLS bool) (*proxyConn
 		if err != nil {
 			return nil, err
 		}
-		conn, err = tls.Dial("tcp", proxyAddr, &tls.Config{RootCAs: roots})
+		tlsConfig := tls.Config{
+			RootCAs:            roots,
+			InsecureSkipVerify: insecure,
+		}
+		conn, err = tls.Dial("tcp", proxyAddr, &tlsConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -37,15 +37,15 @@ type AASessionTemplateModel struct {
 
 // TTYServerConfig is used to configure the tty server before it is started
 type TTYServerConfig struct {
-	FrontListenAddress string
-	FrontendPath       string
-	PTY                PTYHandler
-	SessionID          string
-	AllowTunneling     bool
-	CrossOrigin        bool
-	BaseUrlPath        string
-	GreetTimeout       time.Duration
-	Seats              int
+	FrontListener  net.Listener
+	FrontendPath   string
+	PTY            PTYHandler
+	SessionID      string
+	AllowTunneling bool
+	CrossOrigin    bool
+	BaseUrlPath    string
+	GreetTimeout   time.Duration
+	Seats          int
 }
 
 // TTYServer represents the instance of a tty server
@@ -93,9 +93,7 @@ func NewTTYServer(config TTYServerConfig) (server *TTYServer) {
 	server = &TTYServer{
 		config: config,
 	}
-	server.httpServer = &http.Server{
-		Addr: config.FrontListenAddress,
-	}
+	server.httpServer = &http.Server{}
 	routesHandler := mux.NewRouter()
 
 	installHandlers := func(session string) {
@@ -321,7 +319,7 @@ func (server *TTYServer) Run() (err error) {
 			}
 		})
 	}
-	err = server.httpServer.ListenAndServe()
+	err = server.httpServer.Serve(server.config.FrontListener)
 	log.Debug("Server finished")
 	return
 }

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
@@ -43,6 +44,7 @@ type TTYServerConfig struct {
 	AllowTunneling     bool
 	CrossOrigin        bool
 	BaseUrlPath        string
+	GreetTimeout       time.Duration
 }
 
 // TTYServer represents the instance of a tty server
@@ -288,6 +290,13 @@ func (server *TTYServer) handleWithTemplateHtml(responseWriter http.ResponseWrit
 }
 
 func (server *TTYServer) Run() (err error) {
+	if server.config.GreetTimeout > 0 {
+		time.AfterFunc(server.config.GreetTimeout, func() {
+			if server.session.ttyProtoConnections.Len() == 0 {
+				server.Stop()
+			}
+		})
+	}
 	err = server.httpServer.ListenAndServe()
 	log.Debug("Server finished")
 	return

--- a/server/server.go
+++ b/server/server.go
@@ -45,6 +45,7 @@ type TTYServerConfig struct {
 	CrossOrigin        bool
 	BaseUrlPath        string
 	GreetTimeout       time.Duration
+	Seats              int
 }
 
 // TTYServer represents the instance of a tty server
@@ -161,6 +162,20 @@ func (server *TTYServer) handleTTYWebsocket(w http.ResponseWriter, r *http.Reque
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}
+
+	switch server.config.Seats {
+	case 0:
+		// unlimited
+	case -1:
+		log.Warnf("No longer accepting clients")
+		return
+	default:
+		if server.session.ttyProtoConnections.Len() >= server.config.Seats {
+			log.Warnf("All seats used (%d)", server.config.Seats)
+			return
+		}
+	}
+
 	upgrader := websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
@@ -185,6 +200,12 @@ func (server *TTYServer) handleTTYWebsocket(w http.ResponseWriter, r *http.Reque
 	// On a new connection, ask for a refresh/redraw of the terminal app
 	server.config.PTY.Refresh()
 	server.session.HandleWSConnection(conn)
+
+	// When a connection ends, close the server if
+	// there are no more connections and we can't accept new ones.
+	if server.config.Seats < 0 && server.session.ttyProtoConnections.Len() == 0 {
+		server.httpServer.Close()
+	}
 }
 
 func (server *TTYServer) handleTunnelWebsocket(w http.ResponseWriter, r *http.Request) {
@@ -294,6 +315,9 @@ func (server *TTYServer) Run() (err error) {
 		time.AfterFunc(server.config.GreetTimeout, func() {
 			if server.session.ttyProtoConnections.Len() == 0 {
 				server.Stop()
+			} else {
+				// stop accepting new connections
+				server.config.Seats = -1
 			}
 		})
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -168,7 +168,7 @@ func (server *TTYServer) handleTTYWebsocket(w http.ResponseWriter, r *http.Reque
 		log.Warnf("No longer accepting clients")
 		return
 	default:
-		if server.session.ttyProtoConnections.Len() >= server.config.Seats {
+		if server.session.ttyProtoConnectionsLen() >= server.config.Seats {
 			log.Warnf("All seats used (%d)", server.config.Seats)
 			return
 		}
@@ -201,7 +201,7 @@ func (server *TTYServer) handleTTYWebsocket(w http.ResponseWriter, r *http.Reque
 
 	// When a connection ends, close the server if
 	// there are no more connections and we can't accept new ones.
-	if server.config.Seats < 0 && server.session.ttyProtoConnections.Len() == 0 {
+	if server.config.Seats < 0 && server.session.ttyProtoConnectionsLen() == 0 {
 		server.httpServer.Close()
 	}
 }
@@ -311,7 +311,7 @@ func (server *TTYServer) handleWithTemplateHtml(responseWriter http.ResponseWrit
 func (server *TTYServer) Run() (err error) {
 	if server.config.GreetTimeout > 0 {
 		time.AfterFunc(server.config.GreetTimeout, func() {
-			if server.session.ttyProtoConnections.Len() == 0 {
+			if server.session.ttyProtoConnectionsLen() == 0 {
 				server.Stop()
 			} else {
 				// stop accepting new connections

--- a/server/session.go
+++ b/server/session.go
@@ -13,7 +13,7 @@ type ttyShareSession struct {
 	ttyProtoConnections *list.List
 	isAlive             bool
 	lastWindowSizeMsg   MsgTTYWinSize
-	ptyHandler           PTYHandler
+	ptyHandler          PTYHandler
 }
 
 func copyList(l *list.List) *list.List {
@@ -28,7 +28,7 @@ func newTTYShareSession(ptyHandler PTYHandler) *ttyShareSession {
 
 	ttyShareSession := &ttyShareSession{
 		ttyProtoConnections: list.New(),
-		ptyHandler:           ptyHandler,
+		ptyHandler:          ptyHandler,
 	}
 
 	return ttyShareSession
@@ -70,6 +70,13 @@ func (session *ttyShareSession) forEachReceiverLock(cb func(rcvConn *TTYProtocol
 			break
 		}
 	}
+}
+
+// ttyProtoConnectionsLen is a thread safe length func for the ttyProtoConnections linked list.
+func (session *ttyShareSession) ttyProtoConnectionsLen() int {
+	session.mainRWLock.RLock()
+	defer session.mainRWLock.RUnlock()
+	return session.ttyProtoConnections.Len()
 }
 
 // Will run on the TTYReceiver connection go routine (e.g.: on the websockets connection routine)


### PR DESCRIPTION
Security:

With `-greet-timeout 5s -seats 1` tty-share will accept clients for a limited time and accept only one client.
For backward compat,
*  `-greet-timeout 0s` means unrestricted acceptance period
* `-seats 0` means unrestricted client number

With `-k` tty-share will accept using a proxy with an invalid certificate, both in server and client mode. If not set, make tty-share exit with a dedicated code (2), so callers can take decision on that exit code without having to parse stderr.


Feature:

With `-listen :0` the tty-share server port is auto-allocated. Which make it easier for our API to execute many tty-share concurrently.

With `-greet-timeout` set, the tty-share process will terminate automatically when the last client disconnects.


Note:

I noticed firefox closes the connection after 170s of idling in the console.
Chrome does not, and the connection dies after a much longer timeout set in the haproxy or nginx.
Did you oberve that too ? If so, did you investigate further ?

Thank you for sharing this excellent tool.